### PR TITLE
feat: Footer 컴포넌트 구현 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
+import Footer from './components/Footer';
 import Header from './components/Header';
 
 export default function App() {
   return (
     <>
       <Header />
+      <main className="flex-1">main</main>
+      <Footer />
     </>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="flex flex-col items-center justify-center w-full h-15 p-4 text-xs text-gray-400 line">
+      <p>개인정보 처리방침 | 이용 약관</p>
+      <p>All rights reserved &copy; Codestates</p>
+    </footer>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* main {
+  flex: 1;
+} */
+
 .dropDownMenu {
   position: absolute;
   top: 4.5rem;


### PR DESCRIPTION
## What is this PR?

- Footer 컴포넌트 구현
- Project ticket: [footer 컴포넌트](https://github.com/users/22yuu/projects/3/views/1?pane=issue&itemId=28171934)

## TODO

- [x] Footer 컴포넌트는 모든 페이지 최하단에 위치해야 합니다.
- [x] Footer 컴포넌트 내부 text는 가운데 정렬이 되어야 합니다.

## Test Checklist

- [x] Footer 컴포넌트가 페이지 최하단에 렌더링되었는지 확인.
- [x] Footer 컴포넌트 내부 text는 가운데 정렬로 렌더링되었는지 확인.

## 어려웠던 점

## Secreenshot
![image](https://github.com/22yuu/fe-sprint-coz-shopping/assets/48381447/bf7920d2-2d81-43fe-8275-cbc580e7c967)

