### PR TITLE
Feature/route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Footer from './components/Footer';
 import Header from './components/Header';
 import { ProductProvider } from './context/ProductContext';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import Main from './pages/Main';
+import { Outlet } from 'react-router-dom';
 
 export default function App() {
   const queryClient = new QueryClient();
@@ -12,7 +12,7 @@ export default function App() {
       <Header />
       <ProductProvider>
         <QueryClientProvider client={queryClient}>
-          <Main />
+          <Outlet />
         </QueryClientProvider>
       </ProductProvider>
       <Footer />

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -3,18 +3,18 @@ import bookmark from '../assets/bookmark.svg';
 import product from '../assets/product.svg';
 import { Link } from 'react-router-dom';
 
-export default function DropDownMenu() {
+export default function DropDownMenu({ onClick }) {
   return (
     <div className="flex flex-col dropDownMenu">
       <ul className="flex flex-col">
         <li className="px-2.5 py-3 cursor-default">OOO님, 안녕하세요!</li>
-        <li className="px-2.5 py-3 line">
+        <li className="px-2.5 py-3 line" onClick={onClick}>
           <Link to="productlist">
             <img className="inline mr-2" src={product} alt="상품 아이콘" />
             상품리스트 페이지
           </Link>
         </li>
-        <li className="px-2.5 py-3 line">
+        <li className="px-2.5 py-3 line" onClick={onClick}>
           <Link to="bookmark">
             <img className="inline mr-2" src={bookmark} alt="북마크 아이콘" />
             북마크 페이지

--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import bookmark from '../assets/bookmark.svg';
 import product from '../assets/product.svg';
+import { Link } from 'react-router-dom';
 
 export default function DropDownMenu() {
   return (
@@ -8,16 +9,16 @@ export default function DropDownMenu() {
       <ul className="flex flex-col">
         <li className="px-2.5 py-3 cursor-default">OOO님, 안녕하세요!</li>
         <li className="px-2.5 py-3 line">
-          <a href="#">
+          <Link to="productlist">
             <img className="inline mr-2" src={product} alt="상품 아이콘" />
             상품리스트 페이지
-          </a>
+          </Link>
         </li>
         <li className="px-2.5 py-3 line">
-          <a href="#">
+          <Link to="bookmark">
             <img className="inline mr-2" src={bookmark} alt="북마크 아이콘" />
             북마크 페이지
-          </a>
+          </Link>
         </li>
       </ul>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
         <button className="w-8 h-8" onClick={handleClickHambuger}>
           <img src={hambuger} alt="hambuger-btn" />
         </button>
-        {openDropDown && <DropDownMenu />}
+        {openDropDown && <DropDownMenu onClick={handleClickHambuger} />}
       </section>
     </section>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import hambuger from '../assets/hambuger.svg';
 import logo from '../assets/logo.svg';
 import DropDownMenu from './DropDownMenu';
@@ -15,10 +16,12 @@ export default function Header() {
       data-testid="header-wrapper"
       className="w-full h-20 flex items-center justify-between px-20 py-4 shadow-lg sticky"
     >
-      <section data-testid="left" className="flex hover:cursor-pointer">
-        <img src={logo} alt="logo" className="w-14 h-8 mr-2" />
-        <span className="text-2xl font-bold">COZ Shopping</span>
-      </section>
+      <Link to="/">
+        <section data-testid="left" className="flex">
+          <img src={logo} alt="logo" className="w-14 h-8 mr-2" />
+          <span className="text-2xl font-bold">COZ Shopping</span>
+        </section>
+      </Link>
       <section data-testid="right">
         <button className="w-8 h-8" onClick={handleClickHambuger}>
           <img src={hambuger} alt="hambuger-btn" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,28 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import Main from './pages/Main.tsx';
+import ProductList from './pages/ProductList.tsx';
+import Bookmark from './pages/Bookmark.tsx';
+import NotFound from './pages/NotFound.tsx';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    errorElement: <NotFound />,
+    children: [
+      { index: true, element: <Main /> },
+      { path: 'productlist', element: <ProductList /> },
+      { path: 'bookmark', element: <Bookmark /> },
+    ],
+  },
+]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/src/pages/Bookmark.tsx
+++ b/src/pages/Bookmark.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Bookmark() {
+  return <main className="flex-1">Bookmark Page</main>;
+}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function NotFound() {
+  return <main className="flex-1">Not Found</main>;
+}

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ProductList() {
+  return <main className="flex-1">ProductList Page</main>;
+}


### PR DESCRIPTION
## What is this PR?
- 라우트 기능 구현
- Projet ticket : [라우팅](https://github.com/users/22yuu/projects/3/views/1?pane=issue&itemId=28290403)

## TODO

- [x] 해당 경로에 맞는 페이지로 이동해야 합니다.
   - MainPage: `/`
   - ProductListPage: `/productlist`
   - BookmarkPage: `/bookmark`
   - error: <NotFound />
 
## Test CheckList
- [x] URL을 통해 페이지 이동이 되는지 확인.
- [x] 햄버거 버튼 클릭 시 나타나는 DropDownMenu 버튼을 눌렀을 때 페이지 이동이 되는지 확인.
- [x] 잘못된 경로를 입력했을 때 사용자에게 올바른 경로가 아니라는 것을 알려주는지 확인. 

## 어려웠던 점

## Screenshot
![route](https://github.com/22yuu/fe-sprint-coz-shopping/assets/48381447/f965bb8d-6bcc-465f-bdd8-bbd81d5a418d)

## 버그

라우트 기능 시연하면서 발견한 문제점:
- 사용자가 잘못된 경로로 진입하였을 때 `<Notfound />`를 렌더링해주는데, Header, Footer 컴포넌트가 함께 존재하지 않네요...! 사용자가 언제든지 메인 페이지로 돌아갈 수 있어야 될 것 같습니다.