### PR TITLE
feat: 북마크 버튼 클릭 시 북마크 추가, 삭제 기능 구현 완료

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,16 +1,66 @@
 module.exports = {
   env: {
     browser: true,
-    es2020: true
+    es2020: true,
   },
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:react-hooks/recommended", "plugin:storybook/recommended"],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:storybook/recommended',
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',
-    sourceType: 'module'
+    sourceType: 'module',
   },
-  plugins: ['react-refresh'],
+  plugins: ['react-refresh', 'import'],
   rules: {
-    'react-refresh/only-export-components': 'warn'
-  }
+    'react-refresh/only-export-components': 'warn',
+    'sort-imports': [
+      'error',
+      {
+        ignoreCase: true,
+        ignoreDeclarationSort: true,
+        ignoreMemberSort: false,
+        allowSeparatedGroups: true,
+      },
+    ],
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        groups: [
+          ['builtin', 'external'],
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        pathGroups: [
+          {
+            pattern: 'next',
+            group: 'builtin',
+          },
+          {
+            pattern: 'react',
+            group: 'builtin',
+          },
+          {
+            pattern: '@MyDesignSystem/**',
+            group: 'internal',
+          },
+          {
+            pattern: 'src/**',
+            group: 'internal',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['src/**', '@MyDesignSystem/**'],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+      },
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@babel/preset-react": "^7.18.6",
     "axios": "^1.4.0",
+    "eslint-plugin-import": "^2.27.5",
+    "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,33 @@
 import { useState } from 'react';
+import { Outlet } from 'react-router-dom';
+
 import Footer from './components/Footer';
 import Header from './components/Header';
-import { ProductProvider } from './context/ProductContext';
-import { Outlet } from 'react-router-dom';
 import Modal from './components/Modal';
 
-export default function App() {
+export default function App(props) {
   const [isOpenModal, setOpenModal] = useState(false);
-  const [imgSrc, setImgSrc] = useState('');
-  const [isModalBookmark, setModalBookmark] = useState(false);
-  const [modalText, setModalText] = useState('');
+  const [modalItem, setModalItem] = useState({});
 
   const handleModal = () => {
     setOpenModal(!isOpenModal);
   };
 
-  const handleModalBookmark = () => {
-    setModalBookmark(!isModalBookmark);
-  };
-
   return (
     <>
       <Header />
-      <ProductProvider>
+      {props.outlet ? (
+        props.outlet
+      ) : (
         <Outlet
-          context={{ handleModal, setImgSrc, setModalBookmark, setModalText }}
-        />
-      </ProductProvider>
-      <Footer />
-
-      {isOpenModal && (
-        <Modal
-          imgSrc={imgSrc}
-          handleModal={handleModal}
-          handleModalBookmark={handleModalBookmark}
-          isModalBookmark={isModalBookmark}
-          modalText={modalText}
+          context={{
+            handleModal,
+            setModalItem,
+          }}
         />
       )}
+      <Footer />
+      {isOpenModal && <Modal item={modalItem} handleModal={handleModal} />}
     </>
   );
 }

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -1,34 +1,57 @@
-import React, { useState } from 'react';
+import { nanoid } from 'nanoid';
+import { useEffect, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import types from '../constants/types';
+
 import bookmarkOff from '../assets/bookmark-off.svg';
 import bookmarkOn from '../assets/bookmark-on.svg';
-
-const { Brand, Product, Category, Exhibition } = types;
+import { useBookmark } from '../context/BookmarkContext';
+import getTypeData from '../utils/getTypeData';
 
 export default function ItemCard({ item }) {
   const { title, subTitle, image, price, discount, follower } =
     getTypeData(item);
 
-  const [isBookmark, setIsBookmark] = useState(false);
-  const { handleModal, setImgSrc, setModalBookmark, setModalText } =
-    useOutletContext();
+  const { bookmarkList, handleAddBookmark, handleDeleteBookmark } =
+    useBookmark();
+
+  const [isBookmark, setIsBookmark] = useState(
+    bookmarkList[item.id] !== undefined
+  );
+
+  const { handleModal, setModalItem } = useOutletContext();
 
   const handleBookmark = () => {
-    setIsBookmark(!isBookmark);
+    // add bookmark
+    if (!isBookmark) {
+      setIsBookmark((prev) => !prev);
+      handleAddBookmark({
+        ...bookmarkList,
+        [item.id]: {
+          ...item,
+          bookmarkId: nanoid(),
+        },
+      });
+    }
+    // delete bookmark
+    else {
+      handleDeleteBookmark(item);
+      setIsBookmark((prev) => !prev);
+    }
   };
 
   const onClickItemCard = () => {
     handleModal();
-    setImgSrc(image);
-    setModalText(title);
-    setModalBookmark(isBookmark);
+    setModalItem(item);
   };
 
+  useEffect(() => {
+    setIsBookmark(bookmarkList[item.id] !== undefined);
+  }, [bookmarkList]);
+
   return (
-    <li className="w-1/4 h-64 hover:cursor-pointer" onClick={onClickItemCard}>
+    <li className="w-1/4 h-64 hover:cursor-pointer">
       <div id="imgSection" className="relative w-full h-4/5">
-        <img src={image} className="w-full h-full" />
+        <img src={image} className="w-full h-full" onClick={onClickItemCard} />
         <button className="absolute bottom-1 right-1" onClick={handleBookmark}>
           <img src={isBookmark ? bookmarkOn : bookmarkOff} />
         </button>
@@ -61,41 +84,4 @@ export default function ItemCard({ item }) {
       </div>
     </li>
   );
-}
-
-function getTypeData(item) {
-  let obj = {};
-
-  switch (item.type) {
-    case Brand:
-      obj = {
-        title: item.brand_name,
-        image: item.brand_image_url,
-        follower: item.follower,
-      };
-      break;
-    case Product:
-      obj = {
-        title: item.title,
-        image: item.image_url,
-        price: item.price,
-        discount: item.discountPercentage,
-      };
-      break;
-    case Category:
-      obj = {
-        title: `# ${item.title}`,
-        image: item.image_url,
-      };
-      break;
-    case Exhibition:
-      obj = {
-        title: item.title,
-        subTitle: item.sub_title,
-        image: item.image_url,
-      };
-      break;
-  }
-
-  return obj;
 }

--- a/src/components/ItemList.tsx
+++ b/src/components/ItemList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ItemCard from './ItemCard';
 
 export default function ItemList({ title, items }) {
@@ -6,9 +5,9 @@ export default function ItemList({ title, items }) {
     <section className="w-full mb-10">
       {title && <h2>{title}</h2>}
       <ul className="flex gap-4">
-        {items.map((item) => (
-          <ItemCard key={item.id} item={item} />
-        ))}
+        {items.length > 0
+          ? items.map((item) => <ItemCard key={item.id} item={item} />)
+          : '텅'}
       </ul>
     </section>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,14 +1,42 @@
+import { useState } from 'react';
+import { nanoid } from 'nanoid';
+import { useBookmark } from '../context/BookmarkContext';
+import getTypeData from '../utils/getTypeData';
 import bookmarkOff from '../assets/bookmark-off.svg';
 import bookmarkOn from '../assets/bookmark-on.svg';
 import close from '../assets/close.svg';
 
-export default function Modal({
-  imgSrc,
-  handleModal,
-  handleModalBookmark,
-  isModalBookmark,
-  modalText,
-}) {
+export default function Modal({ item, handleModal }) {
+  const { bookmarkList, handleAddBookmark, handleDeleteBookmark } =
+    useBookmark();
+
+  const { title, image } = getTypeData(item);
+
+  const [isModalBookmark, setModalBookmark] = useState(
+    bookmarkList[item.id] !== undefined
+  );
+
+  const handleModalBookmark = () => {
+    console.log('clicked!!!');
+    if (!isModalBookmark) {
+      const bookmarkSavedTime = new Date().getSeconds();
+      // console.log(bookmarkSavedTime);
+
+      setModalBookmark((prev) => !prev);
+      handleAddBookmark({
+        ...bookmarkList,
+        [item.id]: {
+          ...item,
+          bookmarkId: nanoid(),
+          time: bookmarkSavedTime,
+        },
+      });
+    } else {
+      handleDeleteBookmark(item);
+      setModalBookmark((prev) => !prev);
+    }
+  };
+
   return (
     <div
       className="fixed top-0 left-0 flex items-center justify-center w-full h-full bg-white/50"
@@ -20,7 +48,7 @@ export default function Modal({
       >
         <img
           className="w-full h-full rounded-2xl"
-          src={imgSrc}
+          src={image}
           alt="modal image"
         />
         <button
@@ -33,7 +61,7 @@ export default function Modal({
           <button onClick={handleModalBookmark}>
             <img src={isModalBookmark ? bookmarkOn : bookmarkOff} />
           </button>
-          <h2 className="text-white">{modalText}</h2>
+          <h2 className="text-white">{title}</h2>
         </div>
       </div>
     </div>

--- a/src/constants/itemCounts.js
+++ b/src/constants/itemCounts.js
@@ -1,0 +1,6 @@
+const itemCounts = {
+  defaultCount: 4,
+  maxCount: 10,
+};
+
+export default itemCounts;

--- a/src/context/BookmarkContext.tsx
+++ b/src/context/BookmarkContext.tsx
@@ -1,0 +1,47 @@
+import { useContext, createContext, useEffect, useState } from 'react';
+
+export const BookmarkContext = createContext();
+
+export function BookmarkProvider({ children }) {
+  const [bookmarkList, setBookmarkList] = useState({});
+
+  const handleAddBookmark = (item) => {
+    localStorage.setItem('bookmarkList', JSON.stringify(item));
+    setBookmarkList({ ...item });
+  };
+
+  const handleDeleteBookmark = (item) => {
+    for (let key in bookmarkList) {
+      if (key == item.id) {
+        delete bookmarkList[key];
+        break;
+      }
+    }
+
+    // console.log(bookmarkList);
+    localStorage.setItem('bookmarkList', JSON.stringify(bookmarkList));
+    setBookmarkList({ ...bookmarkList });
+  };
+
+  useEffect(() => {
+    if ('bookmarkList' in localStorage) {
+      const list = JSON.parse(localStorage.bookmarkList);
+      setBookmarkList(list);
+    } else {
+      localStorage.setItem('bookmarkList', '{}');
+    }
+    return;
+  }, []);
+
+  return (
+    <BookmarkContext.Provider
+      value={{ bookmarkList, handleAddBookmark, handleDeleteBookmark }}
+    >
+      {children}
+    </BookmarkContext.Provider>
+  );
+}
+
+export function useBookmark() {
+  return useContext(BookmarkContext);
+}

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -1,7 +1,8 @@
-import React, { useContext, createContext, ReactNode } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
+
 import FakeProductClient from '../api/FakeProductClient';
-import ProductClient from '../api/ProductClient';
 import ProductAPI from '../api/productAPI';
+import ProductClient from '../api/ProductClient';
 
 type ProviderProps = {
   children: ReactNode;
@@ -10,7 +11,7 @@ export const ProductApiContext = createContext();
 
 const fake = new FakeProductClient();
 const client = new ProductClient();
-const productApi = new ProductAPI(fake);
+const productApi = new ProductAPI(client);
 
 export function ProductProvider({ children }: ProviderProps) {
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,20 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+
 import App from './App.tsx';
 import './index.css';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Main from './pages/Main.tsx';
-import ProductList from './pages/ProductList.tsx';
+import { BookmarkProvider } from './context/BookmarkContext';
+import { ProductProvider } from './context/ProductContext';
 import Bookmark from './pages/Bookmark.tsx';
+import Main from './pages/Main.tsx';
 import NotFound from './pages/NotFound.tsx';
+import ProductList from './pages/ProductList.tsx';
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,
-    errorElement: <NotFound />,
+    errorElement: <App outlet={<NotFound />} />,
     children: [
       { index: true, element: <Main /> },
       { path: 'productlist', element: <ProductList /> },
@@ -22,7 +24,9 @@ const router = createBrowserRouter([
 ]);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>
+  <ProductProvider>
+    <BookmarkProvider>
+      <RouterProvider router={router} />
+    </BookmarkProvider>
+  </ProductProvider>
 );

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,21 +1,26 @@
-import React, { useState, useEffect } from 'react';
-import { useProductApi } from '../context/ProductContext';
+import { useEffect, useState } from 'react';
+
 import ItemList from '../components/ItemList';
+import itemCounts from '../constants/itemCounts';
+import { useBookmark } from '../context/BookmarkContext';
+import { useProductApi } from '../context/ProductContext';
 
 export default function Main() {
-  const { productApi } = useProductApi();
-
   const [products, setProducts] = useState([]);
+  const { productApi } = useProductApi();
+  const { bookmarkList } = useBookmark();
 
   useEffect(() => {
-    // productApi.getAllProducts().then((res) => setProducts(res));
-    productApi.getBy(4).then((res) => setProducts(res));
-    // productApi.getBy(10).then((res) => setProducts(res));
+    productApi.getBy(itemCounts.defaultCount).then((res) => setProducts(res));
   }, []);
+
   return (
     <main className="flex-1 flex flex-col items-center justify-center">
       <ItemList title="상품 리스트" items={products} />
-      <ItemList title="북마크 리스트" items={products} />
+      <ItemList
+        title="북마크 리스트"
+        items={Object.values(bookmarkList).slice(0, 4)}
+      />
     </main>
   );
 }

--- a/src/utils/getTypeData.js
+++ b/src/utils/getTypeData.js
@@ -1,0 +1,40 @@
+import types from '../constants/types';
+
+const { Brand, Product, Category, Exhibition } = types;
+
+export default function getTypeData(item) {
+  let obj = {};
+
+  switch (item.type) {
+    case Brand:
+      obj = {
+        title: item.brand_name,
+        image: item.brand_image_url,
+        follower: item.follower,
+      };
+      break;
+    case Product:
+      obj = {
+        title: item.title,
+        image: item.image_url,
+        price: item.price,
+        discount: item.discountPercentage,
+      };
+      break;
+    case Category:
+      obj = {
+        title: `# ${item.title}`,
+        image: item.image_url,
+      };
+      break;
+    case Exhibition:
+      obj = {
+        title: item.title,
+        subTitle: item.sub_title,
+        image: item.image_url,
+      };
+      break;
+  }
+
+  return obj;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2562,6 +2562,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
 "@types/lodash@^4.14.167":
   version "4.14.194"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
@@ -3032,10 +3037,41 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
+array-includes@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
+  integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    is-string "^1.0.7"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array.prototype.flat@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz#ffc6576a7ca3efc2f46a143b9d1dda9b4b3cf5e2"
+  integrity sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.flatmap@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
+  integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
 
 assert@^2.0.0:
   version "2.0.0"
@@ -3811,6 +3847,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
 decimal.js@^10.4.2:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
@@ -3972,6 +4015,13 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -4102,6 +4152,46 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.19.0, es-abstract@^1.20.4:
+  version "1.21.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.21.2.tgz#a56b9695322c8a185dc25975aa3b8ec31d0e7eff"
+  integrity sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-set-tostringtag "^2.0.1"
+    es-to-primitive "^1.2.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.2.0"
+    get-symbol-description "^1.0.0"
+    globalthis "^1.0.3"
+    gopd "^1.0.1"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.5"
+    is-array-buffer "^3.0.2"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-typed-array "^1.1.10"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.3"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
+    string.prototype.trim "^1.2.7"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
+    typed-array-length "^1.0.4"
+    unbox-primitive "^1.0.2"
+    which-typed-array "^1.1.9"
+
 es-get-iterator@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
@@ -4121,6 +4211,31 @@ es-module-lexer@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+
+es-set-tostringtag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
+  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    has-tostringtag "^1.0.0"
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es6-object-assign@^1.1.0:
   version "1.1.0"
@@ -4203,6 +4318,43 @@ escodegen@^2.0.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-import-resolver-node@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"
+  integrity sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==
+  dependencies:
+    debug "^3.2.7"
+    is-core-module "^2.11.0"
+    resolve "^1.22.1"
+
+eslint-module-utils@^2.7.4:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"
+  integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
+  dependencies:
+    debug "^3.2.7"
+
+eslint-plugin-import@^2.27.5:
+  version "2.27.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz#876a6d03f52608a3e5bb439c2550588e51dd6c65"
+  integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flat "^1.3.1"
+    array.prototype.flatmap "^1.3.1"
+    debug "^3.2.7"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.7"
+    eslint-module-utils "^2.7.4"
+    has "^1.0.3"
+    is-core-module "^2.11.0"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.values "^1.1.6"
+    resolve "^1.22.1"
+    semver "^6.3.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
@@ -4678,7 +4830,17 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-functions-have-names@^1.2.3:
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
@@ -4737,6 +4899,14 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 giget@^1.0.0:
   version "1.1.2"
@@ -4836,6 +5006,13 @@ globals@^13.19.0:
   dependencies:
     type-fest "^0.20.2"
 
+globalthis@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  dependencies:
+    define-properties "^1.1.3"
+
 globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -4894,7 +5071,7 @@ harmony-reflect@^1.4.6:
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
   integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
 
-has-bigints@^1.0.1:
+has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
@@ -5085,7 +5262,7 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-internal-slot@^1.0.4:
+internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
   integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
@@ -5158,7 +5335,7 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-callable@^1.1.3:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
@@ -5170,7 +5347,7 @@ is-core-module@^2.11.0, is-core-module@^2.9.0:
   dependencies:
     has "^1.0.3"
 
-is-date-object@^1.0.5:
+is-date-object@^1.0.1, is-date-object@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -5233,6 +5410,11 @@ is-nan@^1.2.1:
   dependencies:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
+
+is-negative-zero@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -5305,14 +5487,14 @@ is-string@^1.0.5, is-string@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-symbol@^1.0.3:
+is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
   integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
     has-symbols "^1.0.2"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.3:
+is-typed-array@^1.1.10, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
   integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
@@ -5327,6 +5509,13 @@ is-weakmap@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
   integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
+
+is-weakref@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-weakset@^2.0.1:
   version "2.0.2"
@@ -5923,6 +6112,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -6220,7 +6416,7 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -6282,7 +6478,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -6307,6 +6503,11 @@ nanoid@^3.3.1, nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+
+nanoid@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
+  integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -6416,7 +6617,7 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-object-inspect@^1.9.0:
+object-inspect@^1.12.3, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
@@ -6443,6 +6644,15 @@ object.assign@^4.1.4:
     define-properties "^1.1.4"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
+
+object.values@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
+  integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 oblivious-set@1.0.0:
   version "1.0.0"
@@ -7178,7 +7388,7 @@ regenerator-transform@^0.15.1:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
-regexp.prototype.flags@^1.5.0:
+regexp.prototype.flags@^1.4.3, regexp.prototype.flags@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
   integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
@@ -7268,7 +7478,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.22.2:
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
   integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
@@ -7340,6 +7550,15 @@ safe-buffer@5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -7611,6 +7830,33 @@ string-length@^4.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string.prototype.trim@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz#a68352740859f6893f14ce3ef1bb3037f7a90533"
+  integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+string.prototype.trimend@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
+  integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+string.prototype.trimstart@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
+  integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -7631,6 +7877,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -7912,6 +8163,16 @@ ts-jest@^29.1.0:
     semver "7.x"
     yargs-parser "^21.0.1"
 
+tsconfig-paths@^3.14.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
+  integrity sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -7986,6 +8247,15 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typed-array-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
+  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    is-typed-array "^1.1.9"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -8000,6 +8270,16 @@ uglify-js@^3.1.4:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
   integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
+    which-boxed-primitive "^1.0.2"
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## What is this PR?
- 북마크 버튼 토글 시 북마크 추가, 삭제 기능 구현
- Project ticket: [북마크 기능 구현](https://github.com/users/22yuu/projects/3?pane=issue&itemId=28358609)

## TODO

- [x] 페이지가 렌더링될 때 LocalStorage에 북마크 리스트가 있는지 여부를 확인합니다.
    - [x] 북마크 리스트가 없으면 LocalStorage에 북마크 리스트를 생성합니다.
    - [x] 북마크 리스트가 존재한다면 `<ItemList />` 컴포넌트의 props로 리스트를 전달합니다.
    - [x] 북마크 리스트의 요소들은 최신순으로 정렬해 사용자에게 보여줍니다.
    - [x] 북마크 리스트안에 북마크된 요소들이 없다면 사용자에게 해당 내용에 관해 시각적 피드백을 제공합니다.

- [x] 사용자가 북마크 버튼을 클릭하면 북마크 리스트에 추가되어야 합니다.
   - [x] 북마크가 되지 않은 요소의 북마크 버튼을 클릭하면 item의 id 값이 북마크 리스트에 저장됩니다.
   - [] 이 때, 최신순 정렬을 위해 현재 시간을 정수로 변환해 함께 저장합니다. (중요한 구현 사항은 아니라고 판단되어 이후 리팩토링 때 구현 예정)
   - [x] 북마크가 되어 있는 요소의 북마크 버튼을 클릭하면 해당 item은 북마크 리스트에서 제거됩니다.
   - [x] 제거된 북마크 요소는 화면 상에서도 없어져야합니다.

- [x] 메인 페이지에서 "상품 리스트" 세션에서도 북마크를 추가할 수 있어야 합니다.
  - [x] 북마크 리스트에 추가된 요소는 "상품 리스트" 화면 상에서 없어져야 합니다.
  - [x] 새롭게 추가된 요소가 북마크 리스트에 나타나야 합니다.
 
(아래의 기능들은 상품 리스트 페이지, 북마크 리스트 페이지 미구현으로 아직 구현이 되지 않았습니다.)
- [] 상품 리스트 페이지에서 북마크를 추가할 수 있어야 합니다.
   - [] 북마크 버튼 클릭시 북마크 추가, 삭제 기능이 동작해야 합니다.
   - [] 북마크가 되지 않은 아이템의 북마크 버튼 클릭 시 북마크 리스트에 추가되고 노란 별 아이콘을 렌더링합니다.
   - [] 북마크된 버튼을 클릭하면 북마크 리스트에서 삭제되고 빈 별 아이콘을 렌덜잏바니다.

-[] 북마크 리스트 페이지에서 북마크된 아이템들을 렌더링해야 합니다.
 - [] 북마크 해제 시 북마크 리스트 페이지에서 제거되어야 합니다.

## Test CheckList
- [x] 메인페이지에서 상품 리스트에서 북마크 버튼 클릭시 북마크 리스트의 화면에서 추가, 삭제 렌더링 확인.
- [x] 모달 창에서의 북마크 추가, 삭제 기능 확인.
- []  상품 리스트 페이지 북마크 추가, 삭제 기능 확인
- [] 북마크 리스트 페이지 북마크 추가, 삭제 기능 확인

## 어려웠던 점 및 궁금한 점

모달창에서의 북마크 추가, 삭제 기능을 구현할 때 고민이 많았습니다. 모달 창의 경우 전역에서 동작하게끔 설계했는데, 북마크 기능의 경우 `<ItemCard />` 컴포넌트 내부에서 동작하게 설계하다보니 해당 아이템의 북마크 추가, 삭제 여부를 모달 창의 북마크 상태까지 공유하지 못해 모달 창 북마크 기능이 의도대로 동작하지 않았습니다.

그래서 Context API를 통해 북마크를 전역 상태로 관리해 모달창까지 함께 구현하였습니다.

- 가장 최상위 `main.tsx`
![image](https://github.com/22yuu/fe-sprint-coz-shopping/assets/48381447/d2acc358-a19d-4d8c-a31e-4bbf5313352b)

이미지를 보시다시피 `<ProductProvider>`, `<BookmarkProvider>` 2개의 `Provider`가 있습니다. `ProductProvider`의 경우 과제의 api를 호출하기 위한 `Provider`입니다. 이 후 `Toast` 기능까지 구현할 때 북마크의 추가, 삭제 시 발생되는 이벤트로 설계를 할 예정인데, 이 경우 북마크가 전역 상태로 관리되고 있다보니 `Toast`의 기능도 전역 상태로 관리해야 될 것 같습니다. 

그럼 또 `<ToastProvider />`라는 것이 생기고 점차 Provider Hell이 발생될 것 같네요... 현재 솔로 프로젝트의 경우 전역으로 관리할 데이터들은 Bookmark, Toast, Api 호출 정도일 것 같긴하네요.

궁금한 점:
1. 저는 이 정도 규모의 경우 리덕스와 같은 상태 관리 라이브러리를 사용하지 않고 리액트의 Context API로 충분할 것 같아 진행하였습니다. 근데 이번 솔로 프로젝트의 북마크와 토스트 기능 같이 어떤 이벤트가 발생했을 때 함께 동작하는 경우 리덕스를 이용해 관리를 해주는게 더 깔끔하다고 생각되네요. 소규모 프로젝트에서 리덕스 같은 상태 관리 라이브러리를 사용하는 것은 조금 과하다고 생각했었는데 이번 과제를 하면서 "굳이 Context API를 써야하나"라는 의문이 들었어요. 특히 북마크와 토스트 기능을 설계를 하면서 useReducer를 쓰면 리덕스처럼 관리할 수 있을 것 같은 생각이 들더라고요. 여기서 "Context API를 왜 쓰는거지 그냥 리덕스 쓰면 되지 않나...?"라는 생각이 들었어요. 과연 소규모, 중규모 프로젝트에서도 성능을 위해 리덕스, 리코일 같은 무거운 라이브러리보다 Context API를 쓰는 이점이 있을까요?

2. 북마크 기능 설계를 전역 상태로 관리하는 방법으로 접근했는데 아무리 생각해봐도 좋은 방법이 아닌 것 같아요. 특히나 Context API의 경우 context의 상태가 변경되면 해당 context 상태를 가지고 있는 컴포넌트가 모두 리렌더링이 되어 페인팅이 일어나므로 성능 면에서 좋지 못해 남용해서 사용하면 좋은 설계가 아니라는 것은 알고 있습니다. 이번에는 어떻게든 기능 구현을 위해 Context API를 사용해 설계했지만 다크모드, 로그인 인증 등 변동이 적은 상태의 경우에만 Context API를 사용하는 것으로 알고 있습니다. 몇몇 예제에서는 모달 창도 Context API로 관리한다는 글을 본적이 있긴하지만 북마크도 Context API로 관리를 해주는 것도 하나의 방법이 될 수 있을까요?

3. 아래의 북마크 기능 시연 이미지를 보시면 북마크를 추가할 때 순서대로 북마크 리스트에 들어가지 않습니다. 이유는 배열에 push를 한게 아니라 아이템의 id를  key값으로 객체를 붙여 렌더링하였는데, 이 id값이 오름차순으로 정렬되어 로컬스토리지에 들어가더라고요. 따로 정렬 로직을 넣지 않았음에도요...! 실시간 세션 때 윤희 멘토님께서 배열을 순차적으로 보여주는 것보다 해시를 이용하며 성능면에서 더 좋다라고 말씀하신게 기억이 남아서 객체로 저장했었습니다. 그래서 북마크리스트에 있는지 없는지 여부를 판별하기 위해 key 값으로 탐색하였습니다. 
![image](https://github.com/22yuu/fe-sprint-coz-shopping/assets/48381447/26a3ff37-b935-4e9f-af0d-4b5b800d629b)
제 생각에는 해시는 정렬되어 있지 않은 상태여도 key 값으로 바로 데이터를 가져올 수 있으니 그냥 객체를 북마크 추가 순서대로 
붙여주면 로컬스토리지에 순서대로 저장될 것으로 기대했는데 의도대로 동작하지 않네요... 북마크 추가 시 순서대로 추가되는 것이 자연스럽고 ux/ui 측면에서 좋을 것으로 생각되어지네요. 지금 떠오르는 방법은 역시 객체로 접근하는 것이 아닌 배열로 접근하는 방법 밖에 떠오르지 않습니다. 혹시 지금 설계를 유지하면서 더 좋은 방향의 리팩토링은 없을까요?

## Screenshot
![bookmark](https://github.com/22yuu/fe-sprint-coz-shopping/assets/48381447/c4b52383-1de3-4e4b-be80-35c22c5e2e9a)
